### PR TITLE
Feature/process multiple add requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ to the remote repo, the script terminates with an exit status of `1`.
 
 Each queue entry file is named per the following template:
 ```
-<YYYYMMDDTHHMMSS.csv>, where:
+<YYYYMMDDTHHMMSSUUUUUU.csv>, where:
   * YYYY = current year
   * MM   = current month,  zero-padded, range: 01-12
   * DD   = current day,    zero-padded  range: 01-31
@@ -61,13 +61,11 @@ Each queue entry file is named per the following template:
   * HH   = current hour,   zero-padded  range: 00-23 (note 24-hour format)
   * MM   = current minute, zero-padded, range: 00-59
   * SS   = current second, zero-padded, range: 00-59
-
-  e.g., 20150106T172954.csv
+  * UUUUUU = current microsecond, zero-padded, range: 000000-999999
+  e.g., 20150213T152104253091.csv
 ```
 A queue-entry file contains a single line of comma-separated values
 that conform to the following template:
 
-`<command>,<absolute path to file being managed>`  
+`<command>,<absolute path to file being managed>`
 `<command>` must be either `add` or `rm`
-
-

--- a/features/process_multiple_add_requests.feature
+++ b/features/process_multiple_add_requests.feature
@@ -1,0 +1,20 @@
+Feature: process multiple add-file requests
+
+  As the git_transactor
+  I want to process multiple 'add-file' requests
+  So that the files are added to the repository
+
+  Scenario: process multiple add-file requests
+    Given that the git repository exists
+    And   there is a request queue
+    And   a source-file directory exists
+    And   a source-file named "foo/bar.txt" exists
+    And   the file "foo/bar.txt" does not exist in the repo
+    And   there is an add-request for "foo/bar.txt" in the queue
+    And   a source-file named "baz/quux.txt" exists
+    And   the file "baz/quux.txt" does not exist in the repo
+    And   there is an add-request for "baz/quux.txt" in the queue
+    When  I process the queue
+    Then  I should see "foo/bar.txt" in the repository
+    And   I should see "baz/quux.txt" in the repository
+    And   I should see "Updating file foo/bar.txt, Updating file baz/quux.txt" in the commit log

--- a/features/step_definitions/multi_entry_steps.rb
+++ b/features/step_definitions/multi_entry_steps.rb
@@ -1,0 +1,24 @@
+Given(/^a source\-file named "(.*?)" exists$/) do |rel_path|
+  subdir = rel_path.split('/')[0]
+  @src_dir.create_sub_directory(subdir)
+  @src_dir.create_file(rel_path, 'whoa! this is SO foo!')
+end
+
+Given(/^the file "(.*?)" does not exist in the repo$/) do |rel_path|
+   g = Git.open(@repo.path)
+   match = g.status.select {|x| x.path == rel_path }
+   expect(match).to be_empty
+end
+
+Given(/^there is a request queue$/) do
+  @tq = TestQueue.new(@work_root); @tq.nuke; @tq.init
+end
+Given(/^there is an add\-request for "(.*?)" in the queue$/) do |rel_path|
+  @tq.enqueue('add', File.expand_path(File.join(@src_dir.path, rel_path)))
+end
+
+Then(/^I should see "(.*?)" in the repository$/) do |rel_path|
+  g = Git.open(@repo.path)
+  match = g.status.select {|x| x.path == rel_path }
+  expect(match).to_not be_empty
+end

--- a/features/support/test_queue.rb
+++ b/features/support/test_queue.rb
@@ -17,7 +17,7 @@ class TestQueue
   def enqueue(action, source_path)
     raise ArgumentError.new("invalid action: #{action}") unless
       ['add','rm'].include?(action)
-    entry = "#{Time.now.strftime("%Y%m%dT%H%M%S")}.csv"
+    entry = "#{Time.now.strftime("%Y%m%dT%H%M%S%6N")}.csv"
     entry_path = File.join(@queue_dir, entry)
     File.open(entry_path, "w") do |f|
       f.puts("#{action},#{source_path}")

--- a/lib/git_transactor/base.rb
+++ b/lib/git_transactor/base.rb
@@ -84,19 +84,22 @@ module GitTransactor
       @repo.add(@file_rel_path)
     end
     def update_commit_msg_for_add_entry
-      @commit_msg += "Updating file #{@file_rel_path}"
+      @commit_msg += (delimiter + "Updating file #{@file_rel_path}")
     end
     def git_rm_file_from_repo
       @repo.remove(@file_rel_path)
     end
     def update_commit_msg_for_rm_entry
-      @commit_msg += "Deleting file #{@file_rel_path}"
+      @commit_msg += (delimiter + "Deleting file #{@file_rel_path}")
     end
     def disposition_entry_file
       FileUtils.mv(@qe.entry_path, File.join(@work_root, 'processed'))
     end
     def update_num_processed
       @num_processed += 1
+    end
+    def delimiter
+      @commit_msg.empty? ? '' : ', '
     end
   end
 end

--- a/spec/git_transactor/base_spec.rb
+++ b/spec/git_transactor/base_spec.rb
@@ -11,67 +11,88 @@ module GitTransactor
                           source_path: source_path,
                           work_root:   work_root) }
 
+    let(:tr) { TestRepo.new(repo_path) }
+    let(:tq) { TestQueue.new(work_root) }
+    let(:tsd){ TestSourceDir.new(source_path) }
+
+    before(:each) do
+      tr.nuke
+      tr.init
+
+      tq.nuke
+      tq.init
+
+      tsd.nuke
+      tsd.init
+    end
+
+    def setup_add_state
+      tsd.create_sub_directory(sub_directory)
+      tsd.create_file(File.join(sub_directory, src_file), "#{src_file}")
+      tq.enqueue('add', File.expand_path(File.join(tsd.path, sub_directory, src_file)))
+    end
+
+    def setup_rm_state
+      tr.create_sub_directory(sub_directory)
+      tr.create_file(file_to_rm_rel_path, "#{file_to_rm}")
+
+      g = Git.open(repo_path)
+      g.add(file_to_rm_rel_path)
+      g.commit("add test file")
+
+      tq.enqueue('rm', File.expand_path(File.join(source_path, file_to_rm_rel_path)))
+    end
+
     context "when class is instantiated" do
-      before(:each) { tr = TestRepo.new(repo_path); tr.nuke; tr.init }
       subject { base }
       it { is_expected.to be_a(GitTransactor::Base) }
     end
 
+
     context "with an empty queue" do
-      before(:each) do
-        tr = TestRepo.new(repo_path);  tr.nuke; tr.init
-        tq = TestQueue.new(work_root); tq.nuke; tq.init
-      end
       it "should return the correct number of entries processed" do
         expect(base.process_queue).to be == 0
       end
     end
 
+
     context "with a single 'add' request in the queue" do
       let(:sub_directory) { 'jgp' }
       let(:src_file) { "interesting-stuff.xml" }
+
       before(:each) do
-        tr  = TestRepo.new(repo_path); tr.nuke; tr.init
-
-        tsd = TestSourceDir.new(source_path); tsd.nuke; tsd.init
-        tsd.create_sub_directory(sub_directory)
-        tsd.create_file(File.join(sub_directory, src_file), "#{src_file}")
-
-        tq = TestQueue.new(work_root); tq.nuke; tq.init
-        tq.enqueue('add', File.expand_path(File.join(tsd.path, sub_directory, src_file)))
+        setup_add_state
       end
+
       it "should return the correct number of entries processed" do
         expect(base.process_queue).to be == 1
       end
+
       it "should move the queue-entry file to the processed directory" do
         base.process_queue
         expect(Dir.glob(File.join(work_root, 'processed','*.csv')).length).to be == 1
       end
     end
+
 
     context "with a single 'rm' request in the queue" do
       let(:sub_directory) { 'pgj' }
       let(:file_to_rm) { "spiffingly-interesting.xml" }
       let(:file_to_rm_rel_path) {File.join(sub_directory, file_to_rm)}
+
       before(:each) do
-        tr  = TestRepo.new(repo_path);  tr.nuke; tr.init
-        tr.create_sub_directory(sub_directory)
-        tr.create_file(file_to_rm_rel_path, "#{file_to_rm}")
-
-        g = Git.open(repo_path)
-        g.add(file_to_rm_rel_path)
-        g.commit("add test file")
-
-        tq = TestQueue.new(work_root); tq.nuke; tq.init
-        tq.enqueue('rm', File.expand_path(File.join(source_path, file_to_rm_rel_path)))
+        setup_rm_state
       end
+
       it "should return the correct number of entries processed" do
         expect(base.process_queue).to be == 1
       end
+
       it "should move the queue-entry file to the processed directory" do
         base.process_queue
         expect(Dir.glob(File.join(work_root, 'processed','*.csv')).length).to be == 1
       end
     end
+
   end
 end

--- a/spec/git_transactor/base_spec.rb
+++ b/spec/git_transactor/base_spec.rb
@@ -32,6 +32,12 @@ module GitTransactor
       tq.enqueue('add', File.expand_path(File.join(tsd.path, sub_directory, src_file)))
     end
 
+    def setup_add_state_2
+      tsd.create_sub_directory(sub_directory_2)
+      tsd.create_file(File.join(sub_directory_2, src_file_2), "#{src_file_2}")
+      tq.enqueue('add', File.expand_path(File.join(tsd.path, sub_directory_2, src_file_2)))
+    end
+
     def setup_rm_state
       tr.create_sub_directory(sub_directory)
       tr.create_file(file_to_rm_rel_path, "#{file_to_rm}")
@@ -72,6 +78,12 @@ module GitTransactor
         base.process_queue
         expect(Dir.glob(File.join(work_root, 'processed','*.csv')).length).to be == 1
       end
+
+      it "should have the correct commit message" do
+        base.process_queue
+        g = Git.open(repo_path)
+        expect(g.log[0].message).to be == 'Updating file jgp/interesting-stuff.xml'
+      end
     end
 
 
@@ -91,6 +103,38 @@ module GitTransactor
       it "should move the queue-entry file to the processed directory" do
         base.process_queue
         expect(Dir.glob(File.join(work_root, 'processed','*.csv')).length).to be == 1
+      end
+
+      it "should have the correct commit message" do
+        base.process_queue
+        g = Git.open(repo_path)
+        expect(g.log[0].message).to be == 'Deleting file pgj/spiffingly-interesting.xml'
+      end
+    end
+
+    context "with two 'add' requests in the queue" do
+      let(:sub_directory) { 'jgp' }
+      let(:src_file) { "interesting-stuff.xml" }
+      let(:sub_directory_2) { 'khq' }
+      let(:src_file_2) { "more-interesting-stuff.xml" }
+      before(:each) do
+        setup_add_state
+        setup_add_state_2
+      end
+
+      it "should return the correct number of entries processed" do
+        expect(base.process_queue).to be == 2
+      end
+
+      it "should move the queue-entry file to the processed directory" do
+        base.process_queue
+        expect(Dir.glob(File.join(work_root, 'processed','*.csv')).length).to be == 2
+      end
+
+      it "should have the correct commit message" do
+        base.process_queue
+        g = Git.open(repo_path)
+        expect(g.log[0].message).to be == 'Updating file jgp/interesting-stuff.xml, Updating file khq/more-interesting-stuff.xml'
       end
     end
 


### PR DESCRIPTION
Highlights:
* Update `.csv` filename requirements to reduce chance of queue-entry collision
* Update `TestQueue` to generate `.csv` files that comply with new filename requirements
* Add more general step definitions to facilitate multiple add-entry scenario
* Add multiple add-file scenario
* Add examples to test multiple add-file scenario
* Update `Base` class to insert delimiter in multi-entry commit messages
