### PR TITLE
Feature/process multiple rm requests

### DIFF
--- a/features/process_multiple_add_requests.feature
+++ b/features/process_multiple_add_requests.feature
@@ -10,10 +10,10 @@ Feature: process multiple add-file requests
     And   a source-file directory exists
     And   a source-file named "foo/bar.txt" exists
     And   the file "foo/bar.txt" does not exist in the repo
-    And   there is an add-request for "foo/bar.txt" in the queue
+    And   there is an "add" request for "foo/bar.txt" in the queue
     And   a source-file named "baz/quux.txt" exists
     And   the file "baz/quux.txt" does not exist in the repo
-    And   there is an add-request for "baz/quux.txt" in the queue
+    And   there is an "add" request for "baz/quux.txt" in the queue
     When  I process the queue
     Then  I should see "foo/bar.txt" in the repository
     And   I should see "baz/quux.txt" in the repository

--- a/features/process_multiple_rm_requests.feature
+++ b/features/process_multiple_rm_requests.feature
@@ -1,0 +1,18 @@
+Feature: process multiple add-file requests
+
+  As the git_transactor
+  I want to process multiple 'add-file' requests
+  So that the files are added to the repository
+
+  Scenario: process multiple add-file requests
+    Given that the git repository exists
+    And   a source-file directory exists
+    And   there is a request queue
+    And   the file "foo/bar.txt" exists in the repo
+    And   the file "baz/quux.txt" exists in the repo
+    And   there is an "rm" request for "foo/bar.txt" in the queue
+    And   there is an "rm" request for "baz/quux.txt" in the queue
+    When  I process the queue
+    Then  the file "foo/bar.txt" does not exist in the repo
+    And   the file "baz/quux.txt" does not exist in the repo
+    And   I should see "Deleting file foo/bar.txt, Deleting file baz/quux.txt" in the commit log

--- a/features/step_definitions/multi_entry_steps.rb
+++ b/features/step_definitions/multi_entry_steps.rb
@@ -13,12 +13,29 @@ end
 Given(/^there is a request queue$/) do
   @tq = TestQueue.new(@work_root); @tq.nuke; @tq.init
 end
-Given(/^there is an add\-request for "(.*?)" in the queue$/) do |rel_path|
-  @tq.enqueue('add', File.expand_path(File.join(@src_dir.path, rel_path)))
+
+Given(/^there is an "(.*?)" request for "(.*?)" in the queue$/) do |action, rel_path|
+     @tq.enqueue(action, File.expand_path(File.join(@src_dir.path, rel_path)))
 end
 
 Then(/^I should see "(.*?)" in the repository$/) do |rel_path|
   g = Git.open(@repo.path)
   match = g.status.select {|x| x.path == rel_path }
   expect(match).to_not be_empty
+end
+
+Given(/^the file "(.*?)" exists in the repo$/) do |rel_path|
+  subdir = rel_path.split('/')[0]
+  @repo.create_sub_directory(subdir)
+  @repo.create_file(rel_path, "#{rel_path}")
+
+  g = Git.open(@repo.path)
+  g.add(rel_path)
+  g.commit("adding test file: #{rel_path}")
+  match = g.status.select {|x| x.path == rel_path }
+  expect(match).to_not be_empty
+end
+
+Given(/^there is an rm\-request for "(.*?)" in the queue$/) do |arg1|
+  pending # express the regexp above with the code you wish you had
 end

--- a/features/step_definitions/multi_entry_steps.rb
+++ b/features/step_definitions/multi_entry_steps.rb
@@ -15,7 +15,7 @@ Given(/^there is a request queue$/) do
 end
 
 Given(/^there is an "(.*?)" request for "(.*?)" in the queue$/) do |action, rel_path|
-     @tq.enqueue(action, File.expand_path(File.join(@src_dir.path, rel_path)))
+  @tq.enqueue(action, File.expand_path(File.join(@src_dir.path, rel_path)))
 end
 
 Then(/^I should see "(.*?)" in the repository$/) do |rel_path|
@@ -34,8 +34,4 @@ Given(/^the file "(.*?)" exists in the repo$/) do |rel_path|
   g.commit("adding test file: #{rel_path}")
   match = g.status.select {|x| x.path == rel_path }
   expect(match).to_not be_empty
-end
-
-Given(/^there is an rm\-request for "(.*?)" in the queue$/) do |arg1|
-  pending # express the regexp above with the code you wish you had
 end


### PR DESCRIPTION
Highlights:
* generalize step definition that enqueues a request so that it can be used for both `add` and `rm` requests
* add step definitions that support the multiple-rm-entry scenario
* add the multiple-rm-entry scenario
