### PR TITLE
update queue entry filename template

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ to the remote repo, the script terminates with an exit status of `1`.
 
 Each queue entry file is named per the following template:
 ```
-<YYYYMMDDTHHMMSSUUUUUU.csv>, where:
+<YYYYMMDDTHHMMSSNNNNNNNNN.csv>, where:
   * YYYY = current year
   * MM   = current month,  zero-padded, range: 01-12
   * DD   = current day,    zero-padded  range: 01-31
@@ -61,8 +61,8 @@ Each queue entry file is named per the following template:
   * HH   = current hour,   zero-padded  range: 00-23 (note 24-hour format)
   * MM   = current minute, zero-padded, range: 00-59
   * SS   = current second, zero-padded, range: 00-59
-  * UUUUUU = current microsecond, zero-padded, range: 000000-999999
-  e.g., 20150213T152104253091.csv
+  * NNNNNNNNN = current nanosecond, zero-padded, range: 000000000-999999999
+  e.g., 20150227T113018273091611.csv
 ```
 A queue-entry file contains a single line of comma-separated values
 that conform to the following template:

--- a/test_support/helpers/test_queue.rb
+++ b/test_support/helpers/test_queue.rb
@@ -15,7 +15,7 @@ class TestQueue < TestDir
   def enqueue(action, source_path)
     raise ArgumentError.new("invalid action: #{action}") unless
       ['add','rm'].include?(action)
-    entry = "#{Time.now.strftime("%Y%m%dT%H%M%S%6N")}.csv"
+    entry = "#{Time.now.strftime("%Y%m%dT%H%M%S%9N")}.csv"
     entry_path = File.join(@queue_dir, entry)
     File.open(entry_path, "w") do |f|
       f.puts("#{action},#{source_path}")


### PR DESCRIPTION
Change queue entry filename template from:
`<YYYYMMDDTHHMMSSUUUUUU.csv>` to `<YYYYMMDDTHHMMSSNNNNNNNNN.csv>`
because linux date utility can easily output nanoseconds,
but not microseconds.  This is relevant because the code
generating the queue entries is a Bash script.