### PR TITLE
Chore/add rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,12 @@
 require "bundler/gem_tasks"
+require_relative "lib/git_transactor"
+
+
+namespace :git_transactor do
+  namespace :setup do
+    desc "Initialize queue structure in QUEUE_ROOT directory"
+    task :queue do
+      GitTransactor::QueueManager.create(ENV["QUEUE_ROOT"])
+    end
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,20 @@
 require "bundler/gem_tasks"
 require_relative "lib/git_transactor"
 
-
 namespace :git_transactor do
   namespace :setup do
     desc "Initialize queue structure in QUEUE_ROOT directory"
     task :queue do
       GitTransactor::QueueManager.create(ENV["QUEUE_ROOT"])
     end
+  end
+  desc "Process entries in queue and push to remote"
+  task :process_and_push do
+    gt = GitTransactor::Base.new(repo_path:   ENV["LOCAL_REPO"],
+                                 source_path: ENV["SOURCE_PATH"],
+                                 work_root:   ENV["QUEUE_ROOT"],
+                                 remote_url:  ENV["REMOTE_REPO_URL"])
+    gt.process_queue
+    gt.push
   end
 end

--- a/features/process_queue_and_push.feature
+++ b/features/process_queue_and_push.feature
@@ -1,0 +1,26 @@
+Feature: process queue and push using Rake
+
+  As a User
+  I want to use a Rake task to process the queue and push to the remote repository
+  So that all additions and deletions are applied locall and are reflected in the remote repository
+
+  @wip
+  Scenario: process queue
+    Given that the remote repository exists
+    And   that the local repository exists and was cloned from the remote repository
+    And   that a queue parent directory exists
+    And   the request queue exists
+    And   a source-file directory exists
+    And   a source-file named "foo/bar.txt" exists
+    And   a source-file named "baz/quux.txt" exists
+    And   the file "circle/square.txt" exists in the repository
+    And   the file "triangle/rhombus.txt" exists in the repository
+    And   there is an "add" request for "foo/bar.txt" in the queue
+    And   there is an "rm" request for "circle/square.txt" in the queue
+    And   there is an "add" request for "baz/quux.txt" in the queue
+    And   there is an "rm" request for "triangle/rhombus.txt" in the queue
+    When  I execute the process and push Rake task
+    Then  I should see "foo/bar.txt" in the repository
+    And   I should see "baz/quux.txt" in the repository
+    And   I should see "Updating file foo/bar.txt, Deleting file circle/square.txt, Updating file baz/quux.txt, Deleting file triangle/rhombus.txt" in the commit log
+    And   the local repository and the remote repository should be in the same state

--- a/features/process_queue_and_push.feature
+++ b/features/process_queue_and_push.feature
@@ -4,8 +4,7 @@ Feature: process queue and push using Rake
   I want to use a Rake task to process the queue and push to the remote repository
   So that all additions and deletions are applied locall and are reflected in the remote repository
 
-  @wip
-  Scenario: process queue
+  Scenario: process queue and push using Rake task
     Given that the remote repository exists
     And   that the local repository exists and was cloned from the remote repository
     And   that a queue parent directory exists

--- a/features/process_queue_and_push.feature
+++ b/features/process_queue_and_push.feature
@@ -1,4 +1,4 @@
-Feature: process queue and push using Rake
+Feature: process queue and push using a Rake task
 
   As a User
   I want to use a Rake task to process the queue and push to the remote repository

--- a/features/setup_queue.feature
+++ b/features/setup_queue.feature
@@ -1,7 +1,7 @@
-Feature: set up queue structure
+Feature: set up queue structure using a Rake task
 
   As a User
-  I want to setup the queue directory
+  I want to setup the queue directory using a Rake task
   So that I can run the git_transactor
 
   Scenario: setup the queue

--- a/features/setup_queue.feature
+++ b/features/setup_queue.feature
@@ -5,6 +5,6 @@ Feature: set up queue structure
   So that I can run the git_transactor
 
   Scenario: setup the queue
-    Given that a parent directory exists
+    Given that a queue parent directory exists
     When  I setup the queue
     Then  I should be able to use the queue

--- a/features/setup_queue.feature
+++ b/features/setup_queue.feature
@@ -6,6 +6,5 @@ Feature: set up queue structure
 
   Scenario: setup the queue
     Given that a parent directory exists
-    And   that directory is writable by the current process
     When  I setup the queue
     Then  I should be able to use the queue

--- a/features/setup_queue.feature
+++ b/features/setup_queue.feature
@@ -1,0 +1,11 @@
+Feature: set up queue structure
+
+  As a User
+  I want to setup the queue directory
+  So that I can run the git_transactor
+
+  Scenario: setup the queue
+    Given that a parent directory exists
+    And   that directory is writable by the current process
+    When  I setup the queue
+    Then  I should be able to use the queue

--- a/features/step_definitions/git_transactor_steps.rb
+++ b/features/step_definitions/git_transactor_steps.rb
@@ -1,7 +1,5 @@
 Given(/^that the git repository exists$/) do
   @repo_path   = 'features/fixtures/repo'
-  @source_path = 'features/fixtures/source'
-  @work_root   = 'features/fixtures/work'
   @remote_repo_path = 'features/fixtures/remote_repo/blerf'
 
   @repo = TestRepo.new(@repo_path)
@@ -13,7 +11,7 @@ Given(/^that the git repository exists$/) do
 end
 
 Given(/^a source\-file directory exists$/) do
-  @src_dir = TestSourceDir.new(@source_path)
+  @src_dir = TestSourceDir.new('features/fixtures/source')
   @src_dir.nuke
   @src_dir.init
 end
@@ -45,6 +43,7 @@ Given(/^the file "(.*?)" does not exist in the repository$/) do |rel_path|
 end
 
 Given(/^the request queue exists$/) do
+  @work_root   = 'features/fixtures/work'
   @tq = TestQueue.new(@work_root); @tq.nuke; @tq.init
 end
 

--- a/features/step_definitions/process_queue_and_push_steps.rb
+++ b/features/step_definitions/process_queue_and_push_steps.rb
@@ -1,0 +1,7 @@
+require 'open3'
+
+When(/^I execute the process and push Rake task$/) do
+  _, e, s = Open3.capture3("rake git_transactor:process_and_push LOCAL_REPO='#{@repo_path}' SOURCE_PATH='#{@src_dir.path}' QUEUE_ROOT='#{@work_root}' REMOTE_REPO_URL='#{@remote_repo_path}'")
+  raise RuntimeError.new(e)unless s == 0
+end
+

--- a/features/step_definitions/push_steps.rb
+++ b/features/step_definitions/push_steps.rb
@@ -7,15 +7,15 @@ Given(/^that the remote repository exists$/) do
 end
 
 Given(/^that the local repository exists and was cloned from the remote repository$/) do
-  @local_repo_parent = 'features/fixtures/local_repo'
-  td = TestDir.new(@local_repo_parent)
+  @repo_parent = 'features/fixtures/local_repo'
+  td = TestDir.new(@repo_parent)
   td.nuke
-  @local_repo_name = 'blerf'
-  @local_repo_path = File.join(@local_repo_parent, @local_repo_name)
-  Git.clone(@remote_repo.path, @local_repo_name, path: @local_repo_parent)
-  @local_repo = TestRepo.new(@local_repo_path)
-  @local_repo.open
-  local_repo_head  = Git.ls_remote(@local_repo.path)['head'][:sha]
+  @repo_name = 'blerf'
+  @repo_path = File.join(@repo_parent, @repo_name)
+  Git.clone(@remote_repo.path, @repo_name, path: @repo_parent)
+  @repo = TestRepo.new(@repo_path)
+  @repo.open
+  local_repo_head  = Git.ls_remote(@repo.path)['head'][:sha]
   remote_repo_head = Git.ls_remote(@remote_repo.path)['head'][:sha]
   expect(local_repo_head).to be == remote_repo_head
 end
@@ -24,17 +24,17 @@ Given(/^the local repository has changes that the remote repository does not$/) 
   rel_path = 'oranges/blueberries.txt'
   subdir = rel_path.split('/')[0]
 
-  @local_repo.create_sub_directory(subdir)
-  @local_repo.create_file(rel_path, 'meaningless drivel')
-  @local_repo.add(rel_path)
-  @local_repo.commit("Updating file #{rel_path}")
-  local_repo_head = Git.ls_remote(@local_repo.path)['head'][:sha]
+  @repo.create_sub_directory(subdir)
+  @repo.create_file(rel_path, 'meaningless drivel')
+  @repo.add(rel_path)
+  @repo.commit("Updating file #{rel_path}")
+  local_repo_head = Git.ls_remote(@repo.path)['head'][:sha]
   remote_repo_head = Git.ls_remote(@remote_repo.path)['head'][:sha]
   expect(local_repo_head).not_to be == remote_repo_head
 end
 
 When(/^I push the local repository to the remote repository$/) do
-  gt = GitTransactor::Base.new(repo_path:   @local_repo.path,
+  gt = GitTransactor::Base.new(repo_path:   @repo.path,
                                source_path: 'features/fixtures/source',
                                work_root:   'features/fixtures/work',
                                remote_url:  @remote_repo_path )
@@ -42,7 +42,7 @@ When(/^I push the local repository to the remote repository$/) do
 end
 
 Then(/^the local repository and the remote repository should be in the same state$/) do
-  local_repo_head  = Git.ls_remote(@local_repo.path)['head'][:sha]
+  local_repo_head  = Git.ls_remote(@repo.path)['head'][:sha]
   remote_repo_head = Git.ls_remote(@remote_repo.path)['head'][:sha]
   expect(local_repo_head).to be == remote_repo_head
 end

--- a/features/step_definitions/setup_queue_steps.rb
+++ b/features/step_definitions/setup_queue_steps.rb
@@ -1,0 +1,16 @@
+require 'open3'
+
+Given(/^that a parent directory exists$/) do
+  td = TestDir.new('features/fixtures/setup_queue')
+  td.nuke
+  td.create_root
+end
+
+When(/^I setup the queue$/) do
+  _, e, s = Open3.capture3('rake git_transactor:setup:queue QUEUE_ROOT=features/fixtures/setup_queue/queue')
+  raise RuntimeError.new(e)unless s == 0
+end
+
+Then(/^I should be able to use the queue$/) do
+  GitTransactor::QueueManager.open('features/fixtures/setup_queue/queue')
+end

--- a/features/step_definitions/setup_queue_steps.rb
+++ b/features/step_definitions/setup_queue_steps.rb
@@ -1,6 +1,6 @@
 require 'open3'
 
-Given(/^that a parent directory exists$/) do
+Given(/^that a queue parent directory exists$/) do
   td = TestDir.new('features/fixtures/setup/queue')
   td.nuke
   td.create_root

--- a/features/step_definitions/setup_queue_steps.rb
+++ b/features/step_definitions/setup_queue_steps.rb
@@ -1,16 +1,16 @@
 require 'open3'
 
 Given(/^that a parent directory exists$/) do
-  td = TestDir.new('features/fixtures/setup_queue')
+  td = TestDir.new('features/fixtures/setup/queue')
   td.nuke
   td.create_root
 end
 
 When(/^I setup the queue$/) do
-  _, e, s = Open3.capture3('rake git_transactor:setup:queue QUEUE_ROOT=features/fixtures/setup_queue/queue')
+  _, e, s = Open3.capture3('rake git_transactor:setup:queue QUEUE_ROOT=features/fixtures/setup/queue/work')
   raise RuntimeError.new(e)unless s == 0
 end
 
 Then(/^I should be able to use the queue$/) do
-  GitTransactor::QueueManager.open('features/fixtures/setup_queue/queue')
+  GitTransactor::QueueManager.open('features/fixtures/setup/queue/work')
 end

--- a/lib/git_transactor/queue_manager.rb
+++ b/lib/git_transactor/queue_manager.rb
@@ -36,7 +36,7 @@ module GitTransactor
       [root,
        File.join(root, QUEUE_SUBDIR),
        File.join(root, PASSED_SUBDIR),
-       File.join(root, FAILED_SUBDIR)].each {|d| Dir.mkdir(d)}
+       File.join(root, FAILED_SUBDIR)].each {|d| Dir.mkdir(d) unless File.directory?(d) }
     end
     def initialize(root)
       @root = root


### PR DESCRIPTION
Implement the following `git_transactor` tasks to `Rakefile`:

```
rake git_transactor:process_and_push  # Process entries in queue and push to remote
rake git_transactor:setup:queue       # Initialize queue structure in QUEUE_ROOT directory
```
