### PR TITLE
add setup before Base class instantiation

### DIFF
--- a/spec/git_transactor/base_spec.rb
+++ b/spec/git_transactor/base_spec.rb
@@ -20,6 +20,7 @@ module GitTransactor
     include Setup::Base
 
     context "when class is instantiated" do
+      before(:each) { setup_initial_state }
       subject { base }
       it { is_expected.to be_a(GitTransactor::Base) }
     end


### PR DESCRIPTION
Checked that all examples and scenarios pased on a freshly cloned repo...
Found that the Base class instantiation example failed.
Added setup code before the example to correct the problem.