### PR TITLE
add teardown methods

### DIFF
--- a/spec/git_transactor/queue_manager_spec.rb
+++ b/spec/git_transactor/queue_manager_spec.rb
@@ -30,12 +30,14 @@ module GitTransactor
         end
         context "when directory is unreadable" do
           before(:each) { setup_unreadable_root }
+          after(:each)  { teardown_unreadable_root }
           it "raises an ArgumentError" do
             expect {GitTransactor::QueueManager.open(unreadable_root)}.to raise_error(ArgumentError, /unreadable/)
           end
         end
         context "when directory is unwritable" do
           before(:each) { setup_unwritable_root }
+          after(:each)  { teardown_unwritable_root }
           it "raises an ArgumentError" do
             expect {GitTransactor::QueueManager.open(unwritable_root)}.to raise_error(ArgumentError, /unwritable/)
           end

--- a/spec/support/setup/queue_manager.rb
+++ b/spec/support/setup/queue_manager.rb
@@ -12,11 +12,8 @@ module GitTransactor
         tq.init
         File.chmod(0333, unreadable_root)
       end
-      def reset_unreadable_root
-        tq = TestQueue.new(unreadable_root)
-        tq.nuke
-        tq.init
-        File.chmod(0333, unreadable_root)
+      def teardown_unreadable_root
+        File.chmod(0755, unreadable_root)
       end
       def setup_unwritable_root
         tq = TestQueue.new(unwritable_root)
@@ -24,11 +21,17 @@ module GitTransactor
         tq.init
         File.chmod(0555, unwritable_root)
       end
+      def teardown_unwritable_root
+        File.chmod(0755, unwritable_root)
+      end
       def setup_unexecutable_root
         tq = TestQueue.new(unexecutable_root)
         tq.nuke
         tq.init
         File.chmod(0666, unexecutable_root)
+      end
+      def teardown_unexecutable_root
+        File.chmod(0755, unexecutable_root)
       end
       def setup_malformed_root
         tq = TestQueue.new(malformed_root)
@@ -48,9 +51,6 @@ module GitTransactor
       end
       def teardown_invalid_create
         File.chmod(0755, File.dirname(invalid_create))
-      end
-      def teardown_unexecutable_root
-        File.chmod(0755, File.dirname(unexecutable_root))
       end
       def setup_empty_queue
         tq = TestQueue.new(empty_queue)


### PR DESCRIPTION
Add teardown methods to helper code, and invoke those methods in
  QueueManager examples so that git repo can be deleted.

  As part of testing, fixture directories are set to be unreadable,
  unwritable, and unexecutable to test that the appropriate exceptions
  are raised.  Leaving the fixure directories in their "test" state,
  however, means that the git repo cannot be deleted without identifying
  and chmod'ding the problematic directories.

  The teardown methods reset the fixture directory permissions so that
  the repo can be deleted recursively.