### PR TITLE
Bug/add to existing subdir

### DIFF
--- a/features/process_add_request.feature
+++ b/features/process_add_request.feature
@@ -16,7 +16,7 @@ Feature: process add-file-request
     And   I should see "Updating file apple/peaches.txt" in the commit log
 
 
-  Scenario: add-file request to existing repo sudbdirectory
+  Scenario: add-file request to existing repo subdirectory
     Given that the git repository exists
     And   the request queue exists
     And   a source-file directory exists

--- a/features/process_add_request.feature
+++ b/features/process_add_request.feature
@@ -14,3 +14,18 @@ Feature: process add-file-request
     When  I process the queue
     Then  I should see "apple/peaches.txt" in the repository
     And   I should see "Updating file apple/peaches.txt" in the commit log
+
+
+  Scenario: add-file request to existing repo sudbdirectory
+    Given that the git repository exists
+    And   the request queue exists
+    And   a source-file directory exists
+    And   a source-file named "apple/peaches.txt" exists
+    And   the file "apple/peaches.txt" does not exist in the repository
+    And   there is an "add" request for "apple/peaches.txt" in the queue
+    And   a source-file named "apple/pears.txt" exists
+    And   the file "apple/pears.txt" does not exist in the repository
+    And   there is an "add" request for "apple/pears.txt" in the queue
+    When  I process the queue
+    Then  I should see "apple/peaches.txt" in the repository
+    And   I should see "Updating file apple/peaches.txt, Updating file apple/pears.txt" in the commit log

--- a/lib/git_transactor/base.rb
+++ b/lib/git_transactor/base.rb
@@ -67,10 +67,11 @@ module GitTransactor
     def setup_paths
       @file_rel_path = Utils.source_path_to_repo_path(@qe.path)
       @dir_rel_path  = File.dirname(@file_rel_path)
+      @dir_tgt_path  = File.join(@repo_path, @dir_rel_path)
       @file_tgt_path = File.join(@repo_path, @file_rel_path)
     end
     def create_repo_subdir_if_needed
-      FileUtils.mkdir(File.join(@repo_path, @dir_rel_path)) unless File.directory?(@dir_rel_path)
+      FileUtils.mkdir(@dir_tgt_path) unless File.directory?(@dir_tgt_path)
     end
     def copy_src_file_to_repo
       FileUtils.cp(@qe.path, @file_tgt_path, preserve: true)

--- a/spec/git_transactor/base_spec.rb
+++ b/spec/git_transactor/base_spec.rb
@@ -60,6 +60,28 @@ module GitTransactor
       end
 
 
+      context "with multiple 'add' requests for the same repo subdirectory in the queue" do
+        before(:each) do
+          setup_add_same_subdir_state
+        end
+
+        it "should return the correct number of entries processed" do
+          expect(base.process_queue).to be == 2
+        end
+
+        it "should move the queue-entry file to the processed directory" do
+          base.process_queue
+          expect(Dir.glob(File.join(work_root, 'passed','*.csv')).length).to be == 2
+        end
+
+        it "should have the correct commit message" do
+          base.process_queue
+          g = Git.open(repo_path)
+          expect(g.log[0].message).to be == 'Updating file jgp/interesting-stuff.xml, Updating file jgp/super-cool-stuff.xml'
+        end
+      end
+
+
       context "with a single 'rm' request in the queue" do
         before(:each) do
           setup_rm_state

--- a/spec/support/setup/base.rb
+++ b/spec/support/setup/base.rb
@@ -36,6 +36,20 @@ module GitTransactor
         tq.enqueue('add', File.expand_path(File.join(tsd.path, sub_directory_2, src_file_2)))
       end
 
+      def setup_add_state_3
+        sub_directory = 'jgp'
+        src_file = "super-cool-stuff.xml"
+
+        tsd.create_sub_directory(sub_directory)
+        tsd.create_file(File.join(sub_directory, src_file), "#{src_file}")
+        tq.enqueue('add', File.expand_path(File.join(tsd.path, sub_directory, src_file)))
+      end
+
+      def setup_add_same_subdir_state
+        setup_add_state
+        setup_add_state_3
+      end
+
       def setup_rm_state
         sub_directory = 'pgj'
         file_to_rm = "spiffingly-interesting.xml"


### PR DESCRIPTION
**Highlights:**
* add example to catch, and code to eliminate, a bug  
  Discovered a bug in the `private` method `Base#create_repo_subdir_if_needed`.  
  The `unless` condition was checking the wrong path, and therefore  
  the `FileUtils.mkdir()` invocation was trying to create a directory that  
  already existed.